### PR TITLE
zookeeper: add version 3.5+ support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ supports         'redhat', '~> 7.0'
 chef_version     '>= 12.10'
 
 depends          'build-essential', '>= 5.0'
-depends          'java', '>= 1.39'
+depends          'java', '< 8.0.0'
 depends          'runit', '>= 1.7'
 depends          'magic', '>= 1.1'
 depends          'ark', '>= 1.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ supports         'centos', '~> 7.0'
 supports         'oracle', '~> 7.0'
 supports         'redhat', '~> 7.0'
 
-chef_version     '>= 13.0'
+chef_version     '>= 12.10'
 
 depends          'build-essential', '>= 5.0'
 depends          'java', '>= 1.39'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'EverTrue'
 maintainer_email 'devops@evertrue.com'
 license          'Apache-2.0'
 description      'Installs/Configures zookeeper'
-version          '12.0.1'
+version          '12.1.0'
 
 issues_url 'https://github.com/evertrue/zookeeper-cookbook/issues'
 source_url 'https://github.com/evertrue/zookeeper-cookbook/'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -61,8 +61,14 @@ action :install do
     recursive true
   end
 
+  url = if Gem::Version.new(new_resource.version) < Gem::Version.new('3.5.0')
+          "#{new_resource.mirror}/zookeeper-#{new_resource.version}/zookeeper-#{new_resource.version}.tar.gz"
+        else
+          "#{new_resource.mirror}/zookeeper-#{new_resource.version}/apache-zookeeper-#{new_resource.version}-bin.tar.gz"
+        end
+
   ark 'zookeeper' do
-    url         "#{new_resource.mirror}/zookeeper-#{new_resource.version}/zookeeper-#{new_resource.version}.tar.gz"
+    url         url
     version     new_resource.version
     prefix_root new_resource.install_dir
     prefix_home new_resource.install_dir


### PR DESCRIPTION
## zookeeper v3.5.x support

Zookeeper artifact naming was changed since version 3.5.x released.
This PR adds compatibility for zookeeper version 3.5+ (backwards compatible)

Changes:
* Fork of [evertrue/zookeeper-cookbook](https://github.com/evertrue/zookeeper-cookbook) created
* Use correct url for zookeeper artifacts download
* Lower minimal Chef version requirement to 12.10
* Lock `java` cookbook version to `< 8.0.0`

@vinted/sre 